### PR TITLE
[WIP] Tileo feature/raster tiled picker clean

### DIFF
--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -325,4 +325,19 @@
     border: 1px solid #eee;
     border-radius: 4px;
     padding: 16px;
+    #message-raster-layer {
+      font-size: 12px;
+      line-height: 14px;
+      color: #636D72;
+      padding: 3px 0;
+      &.error {
+        background: rgba(255, 255, 0, 0.3);
+      }
+    }
+    .CDB-NavMenu-inner {
+      display: block;
+    }
+    .CDB-NavMenu-inner {
+      border: 0;
+    }
 }

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -318,3 +318,11 @@
   text-align: center;
   z-index: -1;
 }
+
+.Editor-ListLayer-item-raster {
+    top: -60%;
+    position: relative;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    padding: 16px;
+}

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -320,11 +320,11 @@
 }
 
 .Editor-ListLayer-item-raster {
-    top: -60%;
-    position: relative;
+    position: absolute;
     border: 1px solid #eee;
     border-radius: 4px;
     padding: 16px;
+    width: calc(100% - 30px);
     #message-raster-layer {
       font-size: 12px;
       line-height: 14px;

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -340,4 +340,7 @@
     .CDB-NavMenu-inner {
       border: 0;
     }
+    .remove-tiled-layer {
+      cursor: pointer;
+    }
 }

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
@@ -11,7 +11,10 @@
 	<h2 class="CDB-Size-large">Raster tiled layers</h2>
 	<div class="raster-tiled-layers-content">
 		<span id="message-raster-layer" style="display:none"></span>
-		<input type="text" name="rasterurl" placeholder="Layer URL"><button> Add layer</button>
+		<span class="CDB-NavMenu-inner CDB-Text is-semibold CDB-Size-medium">
+			<input type="text" name="rasterurl" placeholder="Layer URL" id="layersInputEdit">
+			<button class="Editor-buttonNavigation CDB-Button CDB-Button--small CDB-Button--primary">ADD</button>
+		</span>
 		<p>Layers:</p>
 		<ul></ul>
 	</div>

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
@@ -7,8 +7,7 @@
   </button>
 </nav>
 <div class="Editor-content js-content"></div>
-<div class="Editor-content js-content"></div>
-<div class="CDB-Text">
+<div class="CDB-Text Editor-ListLayer-item-raster">
 	<h2 class="CDB-Size-large">Raster tiled layers</h2>
 	<div class="raster-tiled-layers-content">
 		<span id="message-raster-layer" style="display:none"></span>

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-tab-pane.tpl
@@ -7,3 +7,13 @@
   </button>
 </nav>
 <div class="Editor-content js-content"></div>
+<div class="Editor-content js-content"></div>
+<div class="CDB-Text">
+	<h2 class="CDB-Size-large">Raster tiled layers</h2>
+	<div class="raster-tiled-layers-content">
+		<span id="message-raster-layer" style="display:none"></span>
+		<input type="text" name="rasterurl" placeholder="Layer URL"><button> Add layer</button>
+		<p>Layers:</p>
+		<ul></ul>
+	</div>
+</div>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "<2.0",
     "carto": "cartodb/carto#master",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
+    "cartodb-deep-insights.js": "splashblot/deep-insights.js#tileo",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "cartocolor": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.476",
+  "version": "4.6.477",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.475",
+  "version": "4.6.476",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.47",
+  "version": "4.6.474",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.474",
+  "version": "4.6.475",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "carto": "cartodb/carto#master",
     "cartodb-deep-insights.js": "splashblot/deep-insights.js#tileo",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#v4",
+    "cartodb.js": "splashblot/cartodb.js#v4",
     "cartocolor": "4.0.0",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",


### PR DESCRIPTION
This PR closes https://github.com/splashblot/dronedb/issues/1

This PR allows to add tiled layers to a CARTO Editor 3 visualisation.

We make use of the exposed map over Deep Insights over its [create-dashboard.js](https://github.com/splashblot/deep-insights.js/blob/tileo/src/api/create-dashboard.js#L66) file. I've updated the `package.json` version so it retrieves the data from this repo.

**WIP**: It has a basic styling, will improve it over the weekend.